### PR TITLE
[FIX] change type of PAddr to work on the x86 (32bit machine)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,9 @@ use core::str;
 use core::slice;
 
 /// Value found in %rax after multiboot jumps to our entry point.
-pub const SIGNATURE_RAX: u64 = 0x2BADB002;
+pub const SIGNATURE: usize = 0x2BADB002;
 
-pub type PAddr = u64;
+pub type PAddr = usize;
 
 /// Multiboot struct clients mainly interact with
 /// To create this use Multiboot::new()


### PR DESCRIPTION
Hello
Thank you for your very useful library.
I would like to use this crate in my OS [Axel](https://github.com/mopp/Axel/tree/rusty)
Unfortunately my OS can only work on x86_32.
But, I found that simple modification make this crate work in x86_32 OS.
Then, I created this pull request.
Thanks.