### PR TITLE
Elf sections iterator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ license = "MIT"
 
 [dependencies]
 paste = "1.0"
+bitflags = "1.2.1"

--- a/src/elf_section.rs
+++ b/src/elf_section.rs
@@ -1,3 +1,32 @@
+// This code is heavily inspired by the elf section iterator from the `multiboot2` crate.
+// Please see: https://crates.io/crates/multiboot2
+
+/*
+LICENSE: https://github.com/rust-osdev/multiboot2-elf64/blob/HEAD/LICENSE-MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Philipp Oppermann
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 /// A single generic ELF Section.
 #[derive(Debug)]
 pub struct ElfSection {

--- a/src/elf_section.rs
+++ b/src/elf_section.rs
@@ -1,0 +1,321 @@
+/// A single generic ELF Section.
+#[derive(Debug)]
+pub struct ElfSection {
+    inner: *const u8,
+    string_section: *const u8,
+    entry_size: u32,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C, packed)]
+struct ElfSectionInner32 {
+    name_index: u32,
+    typ: u32,
+    flags: u32,
+    addr: u32,
+    offset: u32,
+    size: u32,
+    link: u32,
+    info: u32,
+    addralign: u32,
+    entry_size: u32,
+}
+
+#[derive(Clone, Copy, Debug)]
+#[repr(C, packed)]
+struct ElfSectionInner64 {
+    name_index: u32,
+    typ: u32,
+    flags: u64,
+    addr: u64,
+    offset: u64,
+    size: u64,
+    link: u32,
+    info: u32,
+    addralign: u64,
+    entry_size: u64,
+}
+
+impl ElfSection {
+    /// Get the section type as a `ElfSectionType` enum variant.
+    pub fn section_type(&self) -> ElfSectionType {
+        match self.get().typ() {
+            0 => ElfSectionType::Unused,
+            1 => ElfSectionType::ProgramSection,
+            2 => ElfSectionType::LinkerSymbolTable,
+            3 => ElfSectionType::StringTable,
+            4 => ElfSectionType::RelaRelocation,
+            5 => ElfSectionType::SymbolHashTable,
+            6 => ElfSectionType::DynamicLinkingTable,
+            7 => ElfSectionType::Note,
+            8 => ElfSectionType::Uninitialized,
+            9 => ElfSectionType::RelRelocation,
+            10 => ElfSectionType::Reserved,
+            11 => ElfSectionType::DynamicLoaderSymbolTable,
+            0x6000_0000..=0x6FFF_FFFF => ElfSectionType::EnvironmentSpecific,
+            0x7000_0000..=0x7FFF_FFFF => ElfSectionType::ProcessorSpecific,
+            _ => panic!(),
+        }
+    }
+
+    /// Get the "raw" section type as a `u32`
+    pub fn section_type_raw(&self) -> u32 {
+        self.get().typ()
+    }
+
+    /// Read the name of the section.
+    pub fn name(&self) -> &str {
+        use core::{slice, str};
+
+        let name_ptr = unsafe { self.string_table().offset(self.get().name_index() as isize) };
+        let strlen = {
+            let mut len = 0;
+            while unsafe { *name_ptr.offset(len) } != 0 {
+                len += 1;
+            }
+            len as usize
+        };
+
+        str::from_utf8(unsafe { slice::from_raw_parts(name_ptr, strlen) }).unwrap()
+    }
+
+    /// Get the physical start address of the section.
+    pub fn start_address(&self) -> u64 {
+        self.get().addr()
+    }
+
+    /// Get the physical end address of the section.
+    ///
+    /// This is the same as doing `section.start_address() + section.size()`
+    pub fn end_address(&self) -> u64 {
+        self.get().addr() + self.get().size()
+    }
+
+    /// Get the section's size in bytes.
+    pub fn size(&self) -> u64 {
+        self.get().size()
+    }
+
+    /// Get the section's address alignment constraints.
+    ///
+    /// That is, the value of `start_address` must be congruent to 0,
+    /// modulo the value of `addrlign`. Currently, only 0 and positive
+    /// integral powers of two are allowed. Values 0 and 1 mean the section has no
+    /// alignment constraints.
+    pub fn addralign(&self) -> u64 {
+        self.get().addralign()
+    }
+
+    /// Get the section's flags.
+    pub fn flags(&self) -> ElfSectionFlags {
+        ElfSectionFlags::from_bits_truncate(self.get().flags())
+    }
+
+    /// Check if the `ALLOCATED` flag is set in the section flags.
+    pub fn is_allocated(&self) -> bool {
+        self.flags().contains(ElfSectionFlags::ALLOCATED)
+    }
+
+    fn get(&self) -> &dyn ElfSectionInner {
+        match self.entry_size {
+            40 => unsafe { &*(self.inner as *const ElfSectionInner32) },
+            64 => unsafe { &*(self.inner as *const ElfSectionInner64) },
+            _ => panic!(),
+        }
+    }
+
+    unsafe fn string_table(&self) -> *const u8 {
+        let addr = match self.entry_size {
+            40 => (*(self.string_section as *const ElfSectionInner32)).addr as usize,
+            64 => (*(self.string_section as *const ElfSectionInner64)).addr as usize,
+            _ => panic!(),
+        };
+        addr as *const _
+    }
+}
+
+trait ElfSectionInner {
+    fn name_index(&self) -> u32;
+
+    fn typ(&self) -> u32;
+
+    fn flags(&self) -> u64;
+
+    fn addr(&self) -> u64;
+
+    fn size(&self) -> u64;
+
+    fn addralign(&self) -> u64;
+}
+
+impl ElfSectionInner for ElfSectionInner32 {
+    fn name_index(&self) -> u32 {
+        self.name_index
+    }
+
+    fn typ(&self) -> u32 {
+        self.typ
+    }
+
+    fn flags(&self) -> u64 {
+        self.flags.into()
+    }
+
+    fn addr(&self) -> u64 {
+        self.addr.into()
+    }
+
+    fn size(&self) -> u64 {
+        self.size.into()
+    }
+
+    fn addralign(&self) -> u64 {
+        self.addralign.into()
+    }
+}
+
+impl ElfSectionInner for ElfSectionInner64 {
+    fn name_index(&self) -> u32 {
+        self.name_index
+    }
+
+    fn typ(&self) -> u32 {
+        self.typ
+    }
+
+    fn flags(&self) -> u64 {
+        self.flags
+    }
+
+    fn addr(&self) -> u64 {
+        self.addr
+    }
+
+    fn size(&self) -> u64 {
+        self.size
+    }
+
+    fn addralign(&self) -> u64 {
+        self.addralign.into()
+    }
+}
+
+/// An enum abstraction over raw ELF section types.
+#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+#[repr(u32)]
+pub enum ElfSectionType {
+    /// This value marks the section header as inactive; it does not have an
+    /// associated section. Other members of the section header have undefined
+    /// values.
+    Unused = 0,
+
+    /// The section holds information defined by the program, whose format and
+    /// meaning are determined solely by the program.
+    ProgramSection = 1,
+
+    /// This section holds a linker symbol table.
+    LinkerSymbolTable = 2,
+
+    /// The section holds a string table.
+    StringTable = 3,
+
+    /// The section holds relocation entries with explicit addends, such as type
+    /// Elf32_Rela for the 32-bit class of object files. An object file may have
+    /// multiple relocation sections.
+    RelaRelocation = 4,
+
+    /// The section holds a symbol hash table.
+    SymbolHashTable = 5,
+
+    /// The section holds dynamic linking tables.
+    DynamicLinkingTable = 6,
+
+    /// This section holds information that marks the file in some way.
+    Note = 7,
+
+    /// A section of this type occupies no space in the file but otherwise resembles
+    /// `ProgramSection`. Although this section contains no bytes, the
+    /// sh_offset member contains the conceptual file offset.
+    Uninitialized = 8,
+
+    /// The section holds relocation entries without explicit addends, such as type
+    /// Elf32_Rel for the 32-bit class of object files. An object file may have
+    /// multiple relocation sections.
+    RelRelocation = 9,
+
+    /// This section type is reserved but has unspecified semantics.
+    Reserved = 10,
+
+    /// This section holds a dynamic loader symbol table.
+    DynamicLoaderSymbolTable = 11,
+
+    /// Values in this inclusive range (`[0x6000_0000, 0x6FFF_FFFF)`) are
+    /// reserved for environment-specific semantics.
+    EnvironmentSpecific = 0x6000_0000,
+
+    /// Values in this inclusive range (`[0x7000_0000, 0x7FFF_FFFF)`) are
+    /// reserved for processor-specific semantics.
+    ProcessorSpecific = 0x7000_0000,
+}
+
+bitflags! {
+    /// ELF Section bitflags.
+    pub struct ElfSectionFlags: u64 {
+        /// The section contains data that should be writable during program execution.
+        const WRITABLE = 0x1;
+
+        /// The section occupies memory during the process execution.
+        const ALLOCATED = 0x2;
+
+        /// The section contains executable machine instructions.
+        const EXECUTABLE = 0x4;
+        // plus environment-specific use at 0x0F000000
+        // plus processor-specific use at 0xF0000000
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ElfSectionIter {
+    current_section: *const u8,
+    remaining_sections: u32,
+    entry_size: u32,
+    string_section: *const u8,
+}
+
+impl Iterator for ElfSectionIter {
+    type Item = ElfSection;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.remaining_sections != 0 {
+            let section = ElfSection {
+                inner: self.current_section,
+                string_section: self.string_section,
+                entry_size: self.entry_size,
+            };
+
+            self.current_section = unsafe { self.current_section.offset(self.entry_size as isize) };
+            self.remaining_sections -= 1;
+
+            if section.section_type() != ElfSectionType::Unused {
+                return Some(section);
+            }
+        }
+        None
+    }
+}
+
+impl ElfSectionIter {
+    pub fn new(
+        first_section: *const u8,
+        num_sections: u32,
+        entry_size: u32,
+        string_section: *const u8,
+    ) -> Self {
+        ElfSectionIter {
+            current_section: first_section,
+            remaining_sections: num_sections,
+            entry_size,
+            string_section,
+        }
+    }
+}

--- a/src/information.rs
+++ b/src/information.rs
@@ -12,6 +12,8 @@ use core::mem::{size_of, transmute};
 use core::slice;
 use core::str;
 
+use elf_section::ElfSectionIter;
+
 /// Value found in %eax after multiboot jumps to our entry point.
 pub const SIGNATURE_EAX: u32 = 0x2BADB002;
 
@@ -902,6 +904,13 @@ impl ElfSymbols {
             num, size, shndx,
             addr: addr.try_into().unwrap(),
         }
+    }
+
+    pub fn sections(&self) -> ElfSectionIter {
+        let first_section_addr = self.addr as *const u8;
+        ElfSectionIter::new(first_section_addr, self.num, self.size, unsafe {
+            first_section_addr.offset((self.size * self.shndx) as isize)
+        })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,9 @@
 #![crate_name = "multiboot"]
 #![crate_type = "lib"]
 
+#[macro_use]
+extern crate bitflags;
+
 macro_rules! round_up {
     ($num:expr, $s:expr) => {
         (($num + $s - 1) / $s) * $s
@@ -45,5 +48,6 @@ macro_rules! flag {
     );
 }
 
-pub mod information;
+pub mod elf_section;
 pub mod header;
+pub mod information;


### PR DESCRIPTION
The goal of this PR is to allow iterating on the elf sections, in the same way as in [the multiboot2 crate](https://crates.io/crates/multiboot2).

As the code is heavily inspired (or straight up copied) from the multiboot2 crate so we have to include the license.

The code still needs some documentation and some tests but I would like your opinion on the way of implementing the feature first.